### PR TITLE
Update 'index.html': Remove double quotations

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,10 +104,10 @@
                         <p>Jacob Pigeon: "Video Game Hacking"</p>
                         <hr>
                         <span class="tag">1:30 pm - 2:00 pm</span>
-                        <p>Luke McManamon: "PFSense""</p>
+                        <p>Luke McManamon: "PFSense"</p>
                         <hr>
                         <span class="tag">2:15 pm - 2:30 pm</span>
-                        <p>Ryan Weber: "AWS Questions and Answers""</p>
+                        <p>Ryan Weber: "AWS Questions and Answers"</p>
                     </p>
                      <hr>
                 <p>


### PR DESCRIPTION
Remove double quotations from talk titles: 'pfsense' and 'AWS Questions and Answers'.