### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
             <div class="content">
                 <h1 class="title is-2">About YoloCon</h1>
                 <p>
-                YoloCon (Ypsilanti Online Learning Opportunity Conference) is an industry engagement conference organized by the <a href="https://emu-iasa.github.io/">Information Assurance Student Association (IASA)</a> at Eastern Michigan University.
+                YoloCon (Ypsilanti Online Learning Opportunity Conference) is an industry engagement conference organized by the <strong> <a href="https://emu-iasa.github.io/">Information Assurance Student Association (IASA)</a> </strong> at Eastern Michigan University.
                 The conference provides a unique opportunity for cybersecurity professionals to speak and inspire the next generation. It is designed for companies to engage with students and professionals in the cybersecurity industry.
                 </p>
                 <p>
@@ -84,6 +84,9 @@
                 YoloCon 23 takes place on <strong>Saturday, April 22nd, 2023.</strong>
                 The conference will be hosted in <strong><a href="https://goo.gl/maps/3ZbZZS6YkwHiDsFW6">Sill Hall, Goodard, Ypsilanti, MI 48197</a>.</strong>
                 </p>
+               <p>
+                The club recently participated at ISTS 23'. A 3-day cyber attack/defend competition hosted by Rochester Institute of Technology (RITSEC).  
+               </p> 
             </div>
             <div class="content mapouter">
                 <div class="gmap_canvas"><iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d824.8761356513874!2d-83.620596!3d42.2485728!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x883ca84edfa237fd%3A0x7a7496775445269!2sSill%20Hall%2C%20Goodard%2C%20Ypsilanti%2C%20MI%2048197!5e1!3m2!1sen!2sus!4v1665545049500!5m2!1sen!2sus" height="300" style="width:100%; border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe></div>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
                 The conference will be hosted in <strong><a href="https://goo.gl/maps/3ZbZZS6YkwHiDsFW6">Sill Hall, Goodard, Ypsilanti, MI 48197</a>.</strong>
                 </p>
                <p>
-                The club recently participated at ISTS 23'. A 3-day cyber attack/defend competition hosted by Rochester Institute of Technology (RITSEC).  
+                The club recently participated at ISTS 2023, a 3-day cyber attack/defend competition hosted by Rochester Institute of Technology (RITSEC).  
                </p> 
             </div>
             <div class="content mapouter">


### PR DESCRIPTION
- Bold IASA link in About YoloCon
- Added "The club participated at ISTS 23' - A 3-day cyber attack/defend competition hosted by Rochester Institute of Technology (RITSEC)." above googlemap. I still need to tweak getting the team photo in there.